### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -4,10 +4,7 @@ RUN apk add --no-cache fontconfig ttf-dejavu && rm -rf /var/cache/apk/*
 
 WORKDIR /home/oereb-web-service
 COPY build/libs/oereb-web-service-docker.jar /home/oereb-web-service/oereb-web-service-docker.jar
-RUN cd /home/oereb-web-service && \
-    chown -R 1001:0 /home/oereb-web-service && \
-    chmod -R g+rw /home/oereb-web-service && \
-    ls -la /home/oereb-web-service
+RUN ls -la
 
 USER 1001
 EXPOSE 8080


### PR DESCRIPTION
Simon Weber hat mich auf das Tool https://github.com/wagoodman/dive aufmerksam gemacht, mit welchem man Docker Images inspizieren kann. Hierauf habe ich die Änderungen in diesem Pull Request gemacht, wodurch sich die Grösse des Images (unkomprimiert) von 252MB auf 187MB reduzieren lässt.

Der Grund: Dadurch, dass bisher nach dem `COPY` von `oereb-web-service-docker.jar` im nächsten Befehl noch ein `chown` und `chmod` stattfand, vergrösserte sich das Image um die Grösse des `oereb-web-service-docker.jar` (65MB), weil dadurch der Image-Layer nochmal modifiziert worden ist, während der `COPY`-Layer aber weiterhin im Image bestehen bleibt.

Falls die Gruppe 0 tatsächlich in /home/oereb-web-service/ schreiben können muss, müsste man noch ein `RUN chmod g+rw .` ergänzen, bzw. dies zum `RUN ls -la` hinzufügen. Aber mir scheint, dass es gar nicht nötig ist.