### PR TITLE
Always import latest image stream tag in test environment

### DIFF
--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -17,6 +17,15 @@ pipeline {
             when { expression { !params.RESTART_ONLY } }
             steps {
                 sh "oc process -f openshift/${appName}.yaml --param-file=openshift/${appName}_${environment}.params | oc apply -f - -n ${params.NAMESPACE}"
+                // In test environment additionally update the latest image stream tag
+                script {
+                    if (environment == 'test') {
+                        // First wait for previous rollout to finish
+                        sh "oc rollout status dc/${appName} -n ${params.NAMESPACE}"
+                        // Update the latest image stream tag
+                        sh "oc import-image ${appName}:latest -o name -n ${params.NAMESPACE}"
+                    }
+                }
             }
         }
         stage('Wait for rollout to finish') {

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -11,13 +11,16 @@ pipeline {
             when { expression { params.RESTART_ONLY } }
             steps {
                 sh "oc rollout latest dc/${appName} -n ${params.NAMESPACE}"
-                sh "oc rollout status dc/${appName} -n ${params.NAMESPACE}"
             }
         }
         stage('Apply configuration') {
             when { expression { !params.RESTART_ONLY } }
             steps {
                 sh "oc process -f openshift/${appName}.yaml --param-file=openshift/${appName}_${environment}.params | oc apply -f - -n ${params.NAMESPACE}"
+            }
+        }
+        stage('Wait for rollout to finish') {
+            steps {
                 sh "oc rollout status dc/${appName} -n ${params.NAMESPACE}"
             }
         }


### PR DESCRIPTION
So kann man in der Testumgebung ein aktualisiertes _latest_ Image deployen, ohne warten zu müssen, bis OpenShift das Image von sich aus aktualisiert und deployt.